### PR TITLE
update util so that parse strips the application's rootURL

### DIFF
--- a/node-tests/fixtures/root-url.html
+++ b/node-tests/fixtures/root-url.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="cache-control" content="no-store" />
+    <meta http-equiv="expires" content="0" />
+    <meta http-equiv="pragma" content="no-cache" />
+    <title>Storybook Ember with rootURL config</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+
+
+<meta name="vault/config/environment" content="%7B%22modulePrefix%22%3A%22vault%22%2C%22environment%22%3A%22development%22%2C%22rootURL%22%3A%22/ui/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22POLLING_URLS%22%3A%5B%22sys/health%22%2C%22sys/replication/status%22%2C%22sys/seal-status%22%5D%2C%22NAMESPACE_ROOT_URLS%22%3A%5B%22sys/health%22%2C%22sys/seal-status%22%2C%22sys/license/features%22%5D%2C%22DEFAULT_PAGE_SIZE%22%3A15%2C%22LOG_TRANSITIONS%22%3Atrue%7D%2C%22flashMessageDefaults%22%3A%7B%22timeout%22%3A7000%2C%22sticky%22%3Afalse%2C%22preventDuplicates%22%3Atrue%7D%2C%22contentSecurityPolicyHeader%22%3A%22Content-Security-Policy%22%2C%22contentSecurityPolicyMeta%22%3Atrue%2C%22contentSecurityPolicy%22%3A%7B%22connect-src%22%3A%5B%22%27self%27%22%5D%2C%22img-src%22%3A%5B%22%27self%27%22%2C%22data%3A%22%5D%2C%22form-action%22%3A%5B%22%27none%27%22%5D%2C%22script-src%22%3A%5B%22%27self%27%22%5D%2C%22style-src%22%3A%5B%22%27unsafe-inline%27%22%2C%22%27self%27%22%5D%2C%22default-src%22%3A%5B%22%27none%27%22%5D%2C%22font-src%22%3A%5B%22%27self%27%22%5D%2C%22media-src%22%3A%5B%22%27self%27%22%5D%7D%2C%22emberData%22%3A%7B%22enableRecordDataRFCBuild%22%3Afalse%7D%2C%22exportApplicationGlobal%22%3Atrue%7D" />
+<meta http-equiv="Content-Security-Policy" content="connect-src 'self' ws://localhost:4200 wss://localhost:4200 ws://0.0.0.0:4200 wss://0.0.0.0:4200; img-src 'self' data:; form-action 'none'; script-src 'self' localhost:4200 0.0.0.0:4200; style-src 'unsafe-inline' 'self'; default-src 'none'; font-src 'self'; media-src 'self'; ">
+<script src="/ui/ember-cli-live-reload.js" type="text/javascript"></script>
+
+    <link rel="stylesheet" href="/ui/assets/vendor.css">
+    <link rel="stylesheet" href="/ui/assets/vault.css">
+    <link rel="icon" type="image/png" href="/ui/favicon.png" />
+
+
+  </head>
+  <body>
+
+
+    <script src="/ui/assets/vendor.js"></script>
+    <script src="/ui/assets/vault.js"></script>
+
+    <div id="ember-basic-dropdown-wormhole"></div>
+  </body>
+</html>

--- a/node-tests/util.js
+++ b/node-tests/util.js
@@ -61,6 +61,43 @@ test('@parse', (t) => {
     });
   });
 
+
+  t.test('should strip rootURL found in config href and src attributes', (t) => {
+    t.plan(1);
+
+    const fileContent = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'root-url.html'), 'utf8');
+
+    t.deepEqual(parse(fileContent), {
+      meta: [{
+        name: 'vault/config/environment',
+        content: '%7B%22modulePrefix%22%3A%22vault%22%2C%22environment%22%3A%22development%22%2C%22rootURL%22%3A%22/ui/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22POLLING_URLS%22%3A%5B%22sys/health%22%2C%22sys/replication/status%22%2C%22sys/seal-status%22%5D%2C%22NAMESPACE_ROOT_URLS%22%3A%5B%22sys/health%22%2C%22sys/seal-status%22%2C%22sys/license/features%22%5D%2C%22DEFAULT_PAGE_SIZE%22%3A15%2C%22LOG_TRANSITIONS%22%3Atrue%7D%2C%22flashMessageDefaults%22%3A%7B%22timeout%22%3A7000%2C%22sticky%22%3Afalse%2C%22preventDuplicates%22%3Atrue%7D%2C%22contentSecurityPolicyHeader%22%3A%22Content-Security-Policy%22%2C%22contentSecurityPolicyMeta%22%3Atrue%2C%22contentSecurityPolicy%22%3A%7B%22connect-src%22%3A%5B%22%27self%27%22%5D%2C%22img-src%22%3A%5B%22%27self%27%22%2C%22data%3A%22%5D%2C%22form-action%22%3A%5B%22%27none%27%22%5D%2C%22script-src%22%3A%5B%22%27self%27%22%5D%2C%22style-src%22%3A%5B%22%27unsafe-inline%27%22%2C%22%27self%27%22%5D%2C%22default-src%22%3A%5B%22%27none%27%22%5D%2C%22font-src%22%3A%5B%22%27self%27%22%5D%2C%22media-src%22%3A%5B%22%27self%27%22%5D%7D%2C%22emberData%22%3A%7B%22enableRecordDataRFCBuild%22%3Afalse%7D%2C%22exportApplicationGlobal%22%3Atrue%7D' }],
+      link: [{
+          rel: 'stylesheet',
+          href: '/assets/vendor.css'
+        },
+        {
+          rel: 'stylesheet',
+          href: '/assets/vault.css'
+        },
+        {
+          rel: 'icon',
+          href: '/favicon.png'
+        }
+      ],
+      script: [
+        {
+          src: '/ember-cli-live-reload.js'
+        },
+        {
+          src: '/assets/vendor.js'
+        },
+        {
+          src: '/assets/vault.js'
+        },
+      ]
+    });
+  });
+
   t.test('should be able to parse built html file and strip out test related files', (t) => {
     t.plan(1);
 

--- a/util.js
+++ b/util.js
@@ -49,6 +49,22 @@ function getDocumentValues($, selector, attributes=[], ignoreRegexs=[]) {
   return config;
 }
 
+function removeRootURL(config) {
+  // extract and parse the application config
+  let appConfig = JSON.parse(decodeURIComponent(config.meta[0].content));
+  let { rootURL } = appConfig;
+	if (!rootURL) return config;
+	config.script = config.script.map(s => {
+		s.src = s.src.replace(rootURL, '/');
+		return s;
+	});
+	config.link = config.link.map(l => {
+		l.href = l.href.replace(rootURL, '/');
+		return l;
+	});
+  return config;
+}
+
 function parse(data, ignoreTestFiles) {
   const ignoreRegexs = ignoreTestFiles ? [/assets\/test/] : []
 
@@ -71,7 +87,7 @@ function parse(data, ignoreTestFiles) {
     }
   }
 
-  return json;
+  return removeRootURL(json);
 }
 
 function objectToHTMLAttributes(obj) {


### PR DESCRIPTION
Hello!

Ember supports using a `rootURL` config in order to serve applications from a root that is not `/` - but it seems like Storybook does not support this (https://github.com/storybooks/storybook/issues/1291) - so after a few failed tries (I looked at webpack `publicPath`, etc) - I decided to just look for the config, and if it's there strip it before `script` and `link` tags get written to `preview-head.html`. 

I'm happy to try other approaches if you think there's a better way. I'll try to update the node tests as well with an example file with `rootURL`.