### PR TITLE
update defaultBlueprint in the ember-addon block

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "defaultBlueprint": "ember-cli-storybook"
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",


### PR DESCRIPTION
Ember blueprints rely on the package name when installing - if there's a mis-match, you can specify the default blueprint via the [`ember-addon` block's `defaultBlueprint`](https://cli.emberjs.com/release/writing-addons/intro-tutorial/#defaultblueprint).

It looks like https://github.com/storybooks/ember-cli-storybook/commit/e8e11387bf2ff4ec9e26115c41a74822aedd8460 changed the package name so `ember install ember-cli-storybook` now gives this error: 
```
The `ember generate <entity-name>` command requires an entity name to be specified. For more details, use `ember help`.
```
This should fix that (though I see it's not published under the new package name, so I haven't tested it).