### PR TITLE
Include asset-manifest in preview-head.html

### DIFF
--- a/node-tests/fixtures/engines.html
+++ b/node-tests/fixtures/engines.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="cache-control" content="no-store" />
+    <meta http-equiv="expires" content="0" />
+    <meta http-equiv="pragma" content="no-cache" />
+    <title>Vault</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+
+
+<meta name="vault/config/environment" content="%7B%22modulePrefix%22%3A%22vault%22%2C%22environment%22%3A%22development%22%2C%22rootURL%22%3A%22/ui/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22POLLING_URLS%22%3A%5B%22sys/health%22%2C%22sys/replication/status%22%2C%22sys/seal-status%22%5D%2C%22NAMESPACE_ROOT_URLS%22%3A%5B%22sys/health%22%2C%22sys/seal-status%22%2C%22sys/license/features%22%5D%2C%22DEFAULT_PAGE_SIZE%22%3A15%2C%22LOG_TRANSITIONS%22%3Atrue%7D%2C%22flashMessageDefaults%22%3A%7B%22timeout%22%3A7000%2C%22sticky%22%3Afalse%7D%2C%22contentSecurityPolicyHeader%22%3A%22Content-Security-Policy%22%2C%22contentSecurityPolicyMeta%22%3Atrue%2C%22contentSecurityPolicy%22%3A%7B%22connect-src%22%3A%5B%22%27self%27%22%5D%2C%22img-src%22%3A%5B%22%27self%27%22%2C%22data%3A%22%5D%2C%22form-action%22%3A%5B%22%27none%27%22%5D%2C%22script-src%22%3A%5B%22%27self%27%22%5D%2C%22style-src%22%3A%5B%22%27unsafe-inline%27%22%2C%22%27self%27%22%5D%2C%22default-src%22%3A%5B%22%27none%27%22%5D%2C%22font-src%22%3A%5B%22%27self%27%22%5D%2C%22media-src%22%3A%5B%22%27self%27%22%5D%7D%2C%22emberData%22%3A%7B%22enableRecordDataRFCBuild%22%3Afalse%7D%2C%22exportApplicationGlobal%22%3Atrue%7D" />
+<meta http-equiv="Content-Security-Policy" content="connect-src 'self' ws://localhost:4200 wss://localhost:4200 ws://0.0.0.0:4200 wss://0.0.0.0:4200; img-src 'self' data:; form-action 'none'; script-src 'self' localhost:4200 0.0.0.0:4200; style-src 'unsafe-inline' 'self'; default-src 'none'; font-src 'self'; media-src 'self'; ">
+<script src="/ui/ember-cli-live-reload.js" type="text/javascript"></script>
+<meta name="replication/config/environment" content="%7B%22modulePrefix%22%3A%22replication%22%2C%22environment%22%3A%22development%22%7D" />
+
+    <link rel="stylesheet" href="/ui/assets/vendor.css">
+    <link rel="stylesheet" href="/ui/assets/vault.css">
+    <link rel="icon" type="image/png" href="/ui/favicon.png" />
+
+    <meta name="vault/config/asset-manifest" content="%7B%22bundles%22%3A%7B%22replication%22%3A%7B%22assets%22%3A%5B%7B%22uri%22%3A%22/ui/engines-dist/replication/assets/engine-vendor.js%22%2C%22type%22%3A%22js%22%7D%2C%7B%22uri%22%3A%22/ui/engines-dist/replication/assets/engine.js%22%2C%22type%22%3A%22js%22%7D%5D%7D%7D%7D" />
+  </head>
+  <body>
+
+
+    <script src="/ui/assets/vendor.js"></script>
+    <script src="/ui/assets/vault.js"></script>
+
+    <div id="ember-basic-dropdown-wormhole"></div>
+  </body>
+</html>
+

--- a/node-tests/util.js
+++ b/node-tests/util.js
@@ -92,6 +92,24 @@ test('@parse', (t) => {
       ]
     });
   });
+
+  t.test('should be able to parse metas from a built html file from an app that uses engines', (t) => {
+    t.plan(1);
+
+    const fileContent = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'engines.html'), 'utf8');
+    const metas = parse(fileContent, true).meta;
+
+    t.deepEqual(metas, [{
+        name: 'vault/config/environment',
+        content: '%7B%22modulePrefix%22%3A%22vault%22%2C%22environment%22%3A%22development%22%2C%22rootURL%22%3A%22/ui/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22POLLING_URLS%22%3A%5B%22sys/health%22%2C%22sys/replication/status%22%2C%22sys/seal-status%22%5D%2C%22NAMESPACE_ROOT_URLS%22%3A%5B%22sys/health%22%2C%22sys/seal-status%22%2C%22sys/license/features%22%5D%2C%22DEFAULT_PAGE_SIZE%22%3A15%2C%22LOG_TRANSITIONS%22%3Atrue%7D%2C%22flashMessageDefaults%22%3A%7B%22timeout%22%3A7000%2C%22sticky%22%3Afalse%7D%2C%22contentSecurityPolicyHeader%22%3A%22Content-Security-Policy%22%2C%22contentSecurityPolicyMeta%22%3Atrue%2C%22contentSecurityPolicy%22%3A%7B%22connect-src%22%3A%5B%22%27self%27%22%5D%2C%22img-src%22%3A%5B%22%27self%27%22%2C%22data%3A%22%5D%2C%22form-action%22%3A%5B%22%27none%27%22%5D%2C%22script-src%22%3A%5B%22%27self%27%22%5D%2C%22style-src%22%3A%5B%22%27unsafe-inline%27%22%2C%22%27self%27%22%5D%2C%22default-src%22%3A%5B%22%27none%27%22%5D%2C%22font-src%22%3A%5B%22%27self%27%22%5D%2C%22media-src%22%3A%5B%22%27self%27%22%5D%7D%2C%22emberData%22%3A%7B%22enableRecordDataRFCBuild%22%3Afalse%7D%2C%22exportApplicationGlobal%22%3Atrue%7D'
+      }, {
+        name: 'replication/config/environment',
+        content: '%7B%22modulePrefix%22%3A%22replication%22%2C%22environment%22%3A%22development%22%7D'
+      }, {
+        name: 'vault/config/asset-manifest',
+        content: '%7B%22bundles%22%3A%7B%22replication%22%3A%7B%22assets%22%3A%5B%7B%22uri%22%3A%22/ui/engines-dist/replication/assets/engine-vendor.js%22%2C%22type%22%3A%22js%22%7D%2C%7B%22uri%22%3A%22/ui/engines-dist/replication/assets/engine.js%22%2C%22type%22%3A%22js%22%7D%5D%7D%7D%7D'
+      }]);
+  });
 });
 
 test('@generatePreviewHead', (t) => {

--- a/util.js
+++ b/util.js
@@ -5,6 +5,9 @@ const lookupTable = {
     selector: 'meta[name*="/config/environment"]',
     attributes: ['name', 'content']
   }, {
+    selector: 'meta[name*="/config/asset-manifest"]',
+    attributes: ['name', 'content']
+  }, {
     selector: 'meta[id]',
     attributes: ['name', 'content', 'id']
   }],


### PR DESCRIPTION
In-repo addons and engines have an asset manifest that gets populated like the application config. This change pulls that meta tag over in the generatePreview function.

There will have to be some updates for https://github.com/storybooks/ember-cli-storybook/pull/5 after this is merged, I will revisit that soon. Thanks!