### PR TITLE
fix rootURL path replace

### DIFF
--- a/util.js
+++ b/util.js
@@ -58,11 +58,11 @@ function removeRootURL(config) {
   let { rootURL } = appConfig;
 	if (!rootURL) return config;
 	config.script = config.script.map(s => {
-		s.src = s.src.replace(rootURL, '/');
+		s.src = s.src.replace(rootURL, './');
 		return s;
 	});
 	config.link = config.link.map(l => {
-		l.href = l.href.replace(rootURL, '/');
+		l.href = l.href.replace(rootURL, './');
 		return l;
 	});
   return config;


### PR DESCRIPTION
When building a static Storybook using `build-storybook`, the `href`s and `src`s in `preview-head.html` were not correctly generated--they were not referring to files actually inside of the directory where the static Storybook is built to. This _should_ fix that. Should fix [this](https://github.com/storybookjs/storybook/issues/4957) issue.