### PR TITLE
Add CircleCI configuration and necessary dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,16 @@ jobs:
           name: Lint
           command: npm run lint
 
-  test:
+  test_node:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests Node
+          command: npm test
+
+  test_default:
     <<: *defaults
     steps:
       - attach_workspace:
@@ -120,7 +129,10 @@ workflows:
       - lint:
           requires:
             - install_dependencies
-      - test:
+      - test_node:
+          requires:
+            - install_dependencies
+      - test_default:
           requires:
             - install_dependencies
       - test_lts_3_4:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,143 @@
+defaults: &defaults
+  docker:
+    - image: circleci/node:10-browsers
+      environment:
+        JOBS: 1
+  working_directory: ~/@storybook/ember-cli-storybook
+
+version: 2
+jobs:
+  checkout_code:
+    <<: *defaults
+    steps:
+      - checkout
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  install_dependencies:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - ember-cli-storybook-node10-v1-{{ checksum "package-lock.json" }}
+      - run: npm config set spin false
+      - run:
+          name: NPM Install
+          command: npm install
+      - save_cache:
+          key: ember-cli-storybook-node10-v1-{{ checksum "package-lock.json" }}
+          paths:
+            - ~/ember-cli-storybook/node_modules
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  lint:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Lint
+          command: npm run lint
+
+  test:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests
+          command: npx ember try:one ember-default --skip-cleanup=true
+
+  test_lts_3_4:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests Ember LTS 3.4
+          command: npx ember try:one ember-lts-3.4 --skip-cleanup=true
+
+  test_lts_3_8:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests Ember LTS 3.8
+          command: npx ember try:one ember-lts-3.8 --skip-cleanup=true
+
+  test_release:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests Ember Release
+          command: npx ember try:one ember-release --skip-cleanup=true
+
+  test_beta:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests Ember Beta
+          command: npx ember try:one ember-beta --skip-cleanup=true
+
+  test_canary:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests Ember Canary
+          command: npx ember try:one ember-canary --skip-cleanup=true
+
+  test_default_with_jquery:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run Tests Ember Default With jQuery
+          command: npx ember try:one ember-default-with-jquery --skip-cleanup=true
+
+workflows:
+  version: 2
+  test_matrix:
+    jobs:
+      - checkout_code
+      - install_dependencies:
+          requires:
+            - checkout_code
+      - lint:
+          requires:
+            - install_dependencies
+      - test:
+          requires:
+            - install_dependencies
+      - test_lts_3_4:
+          requires:
+            - install_dependencies
+      - test_lts_3_8:
+          requires:
+            - install_dependencies
+      - test_release:
+          requires:
+            - install_dependencies
+      - test_beta:
+          requires:
+            - install_dependencies
+      - test_canary:
+          requires:
+            - install_dependencies
+      - test_default_with_jquery:
+          requires:
+            - install_dependencies

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -4,7 +4,7 @@ const getChannelURL = require('ember-source-channel-url');
 
 module.exports = async function() {
   return {
-    command: 'npm test',
+    command: 'ember build',
     scenarios: [
       {
         name: 'ember-lts-3.4',

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const getChannelURL = require('ember-source-channel-url');
+
+module.exports = async function() {
+  return {
+    command: 'npm test',
+    scenarios: [
+      {
+        name: 'ember-lts-3.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.4.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.8.0'
+          }
+        }
+      },
+      {
+        name: 'ember-release',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('release')
+          }
+        }
+      },
+      {
+        name: 'ember-beta',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('beta')
+          }
+        }
+      },
+      {
+        name: 'ember-canary',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('canary')
+          }
+        }
+      },
+      {
+        name: 'ember-default',
+        npm: {
+          devDependencies: {}
+        }
+      },
+      {
+        name: 'ember-default-with-jquery',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({
+            'jquery-integration': true
+          })
+        },
+        npm: {
+          devDependencies: {
+            '@ember/jquery': '^0.5.1'
+          }
+        }
+      }
+    ]
+  };
+};

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -4,7 +4,7 @@ const getChannelURL = require('ember-source-channel-url');
 
 module.exports = async function() {
   return {
-    command: 'mkdir .storybook && ember build',
+    command: 'mkdir .storybook && npm run build-storybook',
     scenarios: [
       {
         name: 'ember-lts-3.4',

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -4,7 +4,7 @@ const getChannelURL = require('ember-source-channel-url');
 
 module.exports = async function() {
   return {
-    command: 'ember build',
+    command: 'mkdir .storybook && ember build',
     scenarios: [
       {
         name: 'ember-lts-3.4',

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const path = require('path');
 const { parse, generatePreviewHead } = require('./util');
 
 module.exports = {
-  name: 'ember-cli-storybook',
+  name: '@storybook/ember-cli-storybook',
 
   outputReady: function(result) {
     if (!this.app) {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
+    "@storybook/ember": "^5.2.3",
     "cheerio": "^1.0.0-rc.2",
     "ember-cli-babel": "^7.1.2"
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "build": "ember build",
+    "build-storybook": "ember build && build-storybook -s dist",
     "lint": "eslint .",
     "start": "ember serve",
     "test": "tape node-tests/**.js",


### PR DESCRIPTION
This is adapted from what ember-circleci generates to
change the lint step to match what’s in package.json,
correct the test command, and use compatible cache keys.

An unfortunate caveat is that in my attempt to add this to
a real application, I found that I needed to add `@storybook/ember`
to `package.json` manually, so these tests passing doesn’t
actually mean the addon is usable in an Ember application. That
can be addressed separately, though; if anyone has advice on
how to add tests around that, let me know.