### PR TITLE
Deal with issue #16 move injection of runningTest

### DIFF
--- a/util.js
+++ b/util.js
@@ -123,12 +123,11 @@ function generatePreviewHead(parsedConfig) {
           </script>`);
           continue;
         }
-        if(value.src.indexOf('assets/vendor.js') > -1) {
-          // make sure we push this before vendor gets loaded to ensure the application does not bind to the window
-          doc.push('<script>runningTests = true;</script>');
-        }
-
         doc.push(`<${key} ${objectToHTMLAttributes(value)}></${key}>`);
+        if(value.src.indexOf('assets/vendor.js') > -1) {
+          // make sure we push this right after vendor to ensure the application does not bind to the window. 
+          doc.push('<script>runningTests = true; Ember.testing=true;</script>');
+        }
       } else {
         doc.push(`<${key} ${objectToHTMLAttributes(value)} />`);
       }


### PR DESCRIPTION
Moves the injection of the runningTest=true statement to right after vendor.js. Ember doesn't mount the application until end of your-app.js which is always loaded after vendor.js. What was found was that at beginning of vendor.js Ember explicitly sets the runningTest flag to false. This overrides the runningTest=true; statement that happened just before the vendor.js script tag.

Also, this adds Ember.testing = true in the same place which other app-wide plugins have been known to check to prevent application specific behaviour.