### PR TITLE
Update ember-cli-inject-live-reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ember-cli-eslint": "^4.2.3",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^1.0.3",
-    "ember-cli-inject-live-reload": "^1.8.2",
+    "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-qunit": "^4.3.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.1",


### PR DESCRIPTION
This silences the deprecation warning that happens when
you run Storybook:

```
Upgrade ember-cli-inject-live-reload version to 1.10.0 or above
```

Since this package already doesn’t support Node 4, it was safe
to update to the 2.* series, as the [breaking change](https://github.com/ember-cli/ember-cli-inject-live-reload/releases/tag/v2.0.2) was just
the dropping of Node 4 support.