### PR TITLE
Auto doc generation from YUI doc comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,12 +31,7 @@ module.exports = {
     let options = this._getOptions();
     let componentFilePathPatterns = options.componentFilePathPatterns || ['app/components/*.js', 'lib/**/addon/components/*.js'];
 
-    if (type !== 'all') {
-      return appTree;
-    }
-
-    if (type === 'all' && options.autoDocEnabled === false) {
-      this.ui.write('ember-cli-storybook is not generating json documentation: autoDocEnabled was false.');
+    if (type !== 'all' || !options.enableAddonDocsIntegration) {
       return appTree;
     }
 

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
+    "broccoli-merge-trees": "^3.0.2",
     "ember-ajax": "^3.1.0",
     "ember-cli": "~3.5.0-beta.1",
+    "ember-cli-addon-docs-esdoc": "^0.2.3",
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-eslint": "^4.2.3",
     "ember-cli-htmlbars": "^3.0.0",
@@ -64,6 +66,7 @@
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",
+    "ember-cli-addon-docs-yuidoc": "^0.2.3",
     "ember-cli-babel": "^7.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "broccoli-merge-trees": "^3.0.2",
     "ember-ajax": "^3.1.0",
     "ember-cli": "~3.5.0-beta.1",
-    "ember-cli-addon-docs-esdoc": "^0.2.3",
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-eslint": "^4.2.3",
     "ember-cli-htmlbars": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config",
-    "defaultBlueprint": "ember-cli-storybook"
+    "configPath": "tests/dummy/config"
   },
   "dependencies": {
+    "broccoli-funnel": "^2.0.2",
     "cheerio": "^1.0.0-rc.2",
     "ember-cli-addon-docs-yuidoc": "^0.2.3",
     "ember-cli-babel": "^7.1.2"


### PR DESCRIPTION
This PR adds autogeneration of a JSON document (using https://github.com/ember-learn/ember-cli-addon-docs-yuidoc) that will be used for storybook docs mode. 

There are a couple of options available for the build:

`enableAddonDocsIntegration`: set this to `true` if you're not interested in using auto-generated props tables in docs mode
`componentFilePathPatterns`: this is an array of paths/glob patters/ regex that gets passed directly to `broccoli-funnel`'s `include` option to find all of the component JS to search for doc comments. This defaults to searching `['app/components/*.js', 'lib/**/addon/components/*.js']` - so all of your app component js and any in-repo addon component js.

The output of the new funnel is a single file: `/storybook-docgen/index.json` - this path is important as you'll need to import this in your storybook config and pass it to the new ember `setJSONDoc` function.
