### PR TITLE
Add defaultBlueprint declaration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "defaultBlueprint": "ember-cli-storybook"
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.2",


### PR DESCRIPTION
https://github.com/storybookjs/ember-cli-storybook/commit/1de55992b34dfa5afc1d7181a0f3a1c7ee8e9b1a#diff-b9cfc7f2cdf78a7f4b91a753d10865a2 erroneously removed the `defaultBlueprint` declaration so the default blueprint's `afterInstall` hook isn't currently running. This means that the necessary dependencies need to be installed manually.