### PR TITLE
Makes sure that only URLs that begin with the rootURL get converted to relative paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = {
     if (!this.app) {
       // You will need ember-cli >= 1.13 to use ember-cli-deploy's postBuild integration.
       // This is because prior to 1.13, `this.app` is not available in the outputReady hook.
-      this.ui.writeLine('please upgrade to ember-cli >= 1.13')
+      this.ui.writeErrorLine('please upgrade to ember-cli >= 1.13')
       return;
     }
 
@@ -75,30 +75,30 @@ module.exports = {
 
     let fileContents = '';
 
-    this.ui.writeLine('Generating files needed by Storybook');
+    this.ui.writeDebugLine('Generating files needed by Storybook');
 
     if(fs.existsSync(testFilePath)) {
       fileContents = fs.readFileSync(testFilePath);
 
-      this.ui.writeLine(`Parsing ${testFilePath}`);
+      this.ui.writeDebugLine(`Parsing ${testFilePath}`);
     } else {
       fileContents = fs.readFileSync(distFilePath);
 
-      this.ui.writeLine(`Parsing ${distFilePath}`);
+      this.ui.writeDebugLine(`Parsing ${distFilePath}`);
     }
 
     const parsedConfig = parse(fileContents, ignoreTestFiles);
 
-    this.ui.writeLine('Generating preview-head.html');
+    this.ui.writeDebugLine('Generating preview-head.html');
 
     const previewHead = generatePreviewHead(parsedConfig);
 
-    this.ui.writeLine('Generating files needed by Storybook');
+    this.ui.writeDebugLine('Generating files needed by Storybook');
 
     fs.mkdirSync(previewHeadDirectory, { recursive: true });
     fs.writeFileSync(previewHeadFilePath, previewHead);
 
-    this.ui.writeLine('Generating .env');
+    this.ui.writeDebugLine('Generating .env');
 
     if(fs.existsSync(path.resolve(process.cwd(), '.env'))) {
       let fileContent = fs.readFileSync(envFilePath, 'utf8');

--- a/node-tests/fixtures/root-url.html
+++ b/node-tests/fixtures/root-url.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="/ui/assets/vendor.css">
     <link rel="stylesheet" href="/ui/assets/vault.css">
     <link rel="icon" type="image/png" href="/ui/favicon.png" />
-
+    <link rel="stylesheet" href="http://example.com/external/style.css">
 
   </head>
   <body>
@@ -25,6 +25,7 @@
 
     <script src="/ui/assets/vendor.js"></script>
     <script src="/ui/assets/vault.js"></script>
+    <script src="http://example.com/external/script.js"></script>
 
     <div id="ember-basic-dropdown-wormhole"></div>
   </body>

--- a/node-tests/util.js
+++ b/node-tests/util.js
@@ -82,6 +82,10 @@ test('@parse', (t) => {
         {
           rel: 'icon',
           href: './favicon.png'
+        },
+        {
+          rel: 'stylesheet',
+          href: 'http://example.com/external/style.css'
         }
       ],
       script: [
@@ -93,6 +97,9 @@ test('@parse', (t) => {
         },
         {
           src: './assets/vault.js'
+        },
+        {
+          src: 'http://example.com/external/script.js'
         },
       ]
     });

--- a/util.js
+++ b/util.js
@@ -53,7 +53,7 @@ function getDocumentValues($, selector, attributes=[], ignoreRegexs=[]) {
 }
 
 function escape(string) {
-  return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+  return string.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
 function removeRootURL(config) {

--- a/util.js
+++ b/util.js
@@ -52,19 +52,26 @@ function getDocumentValues($, selector, attributes=[], ignoreRegexs=[]) {
   return config;
 }
 
+function escape(string) {
+  return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
 function removeRootURL(config) {
   // extract and parse the application config
   let appConfig = JSON.parse(decodeURIComponent(config.meta[0].content));
   let { rootURL } = appConfig;
-	if (!rootURL) return config;
-	config.script = config.script.map(s => {
-		s.src = s.src.replace(rootURL, './');
-		return s;
-	});
-	config.link = config.link.map(l => {
-		l.href = l.href.replace(rootURL, './');
-		return l;
-	});
+  if (!rootURL) return config;
+
+  let pattern = new RegExp(`^${escape(rootURL)}`);
+
+  config.script = config.script.map(s => {
+    s.src = s.src.replace(pattern, './');
+    return s;
+  });
+  config.link = config.link.map(l => {
+    l.href = l.href.replace(pattern, './');
+    return l;
+  });
   return config;
 }
 
@@ -127,7 +134,7 @@ function generatePreviewHead(parsedConfig) {
         }
         doc.push(`<${key} ${objectToHTMLAttributes(value)}></${key}>`);
         if(value.src.indexOf('assets/vendor.js') > -1) {
-          // make sure we push this right after vendor to ensure the application does not bind to the window. 
+          // make sure we push this right after vendor to ensure the application does not bind to the window.
           doc.push('<script>runningTests = true; Ember.testing=true;</script>');
         }
       } else {


### PR DESCRIPTION
This fixes including additional resources (such as styles) from external servers using absolute paths. Fixes #29