### PR TITLE
only replace `rootUrl` in the beginning of the string

### DIFF
--- a/util.js
+++ b/util.js
@@ -58,11 +58,11 @@ function removeRootURL(config) {
   let { rootURL } = appConfig;
 	if (!rootURL) return config;
 	config.script = config.script.map(s => {
-		s.src = s.src.replace(rootURL, './');
+		s.src = s.src.replace(new RegExp(`^${rootURL}`), './');
 		return s;
 	});
 	config.link = config.link.map(l => {
-		l.href = l.href.replace(rootURL, './');
+		l.href = l.href.replace(new RegExp(`^${rootURL}`), './');
 		return l;
 	});
   return config;


### PR DESCRIPTION
the urls in our projects are absolute urls on another domain and `rootUrl` is set to `/` so the old code resulted in `http:.//...` urls.

I am not 100% following in which scenarios this replacement has to be done but I assume it should only be replaced if the `src`/`href` starts with it. This code should still do that.