### PR TITLE
✨ Add autogeneration documentation for Ember Addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,12 @@ module.exports = {
   postprocessTree(type, appTree) {
     this._super.postprocessTree.apply(this, arguments);
     let options = this._getOptions();
-    let componentFilePathPatterns = options.componentFilePathPatterns || ['app/components/*.js', 'lib/**/addon/components/*.js'];
+
+    let componentFilePathPatterns = options.componentFilePathPatterns || [
+      'app/components/*.js',
+      'lib/**/addon/components/*.js',
+      'addon/components/*.js',
+    ];
 
     if (type !== 'all' || !options.enableAddonDocsIntegration) {
       return appTree;


### PR DESCRIPTION
This MR aims to fix the **autogeneration of a JSON documentation** for Ember addons that it used by `storybook/addons/docs`.
Indeed, as today, autogeneration of JSON documentation was **only working for Ember apps and Ember engine** that belong into a Ember app.

Because of the missing path, the generated `index.json` was empty. **It's now fixed**.


` 'app/components/*.js'` -> path for Ember apps
`'lib/**/addon/components/*.js'` -> path for component of Ember engine inside an Ember app
`'addon/components/*.js'` -> path for Ember addons
