### PR TITLE
ember-cli-update v3.5.0-beta.1...v3.20.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@
 
 root = true
 
-
 [*]
 end_of_line = lf
 charset = utf-8

--- a/.eslintignore
+++ b/.eslintignore
@@ -7,12 +7,12 @@
 /tmp/
 
 # dependencies
-/bower_components/
+/node_modules/
 
 # misc
 /coverage/
+!.*
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
 /package.json.ember-try

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,12 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
-    ecmaVersion: 2017,
-    sourceType: 'module'
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      legacyDecorators: true
+    }
   },
   extends: 'eslint:recommended',
   env: {
@@ -10,6 +14,35 @@ module.exports = {
     node: true,
     mocha: true
   },
-  rules: {
-  }
+  rules: {},
+  overrides: [
+    // node files
+    {
+      files: [
+        '.eslintrc.js',
+        '.template-lintrc.js',
+        'ember-cli-build.js',
+        'index.js',
+        'testem.js',
+        'blueprints/*/index.js',
+        'config/**/*.js',
+        'tests/dummy/config/**/*.js'
+      ],
+      excludedFiles: [
+        'addon/**',
+        'addon-test-support/**',
+        'app/**',
+        'tests/dummy/app/**'
+      ],
+      parserOptions: {
+        sourceType: 'script'
+      },
+      env: {
+        browser: false,
+        node: true
+      },
+      plugins: ['node'],
+      extends: ['plugin:node/recommended']
+    }
+  ]
 };

--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,15 @@
 /tmp/
 
 # dependencies
-/bower_components/
 /node_modules/
 
+# storybook
+/storybook-static/
+/.storybook/preview-head.html
+
 # misc
+/.env*
+/.pnp*
 /.sass-cache
 /connect.lock
 /coverage/
@@ -19,7 +24,6 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
 /package.json.ember-try
 package-lock.json
 yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -2,20 +2,19 @@
 /dist/
 /tmp/
 
-# dependencies
-/bower_components/
-
 # misc
-/.bowerrc
 /.editorconfig
 /.ember-cli
+/.env*
 /.eslintignore
 /.eslintrc.js
+/.git/
 /.gitignore
-/.watchmanconfig
+/.template-lintrc.js
 /.travis.yml
-/bower.json
+/.watchmanconfig
 /config/ember-try.js
+/CONTRIBUTING.md
 /ember-cli-build.js
 /testem.js
 /tests/
@@ -24,5 +23,4 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
 /package.json.ember-try

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: 'recommended'
+  extends: 'octane'
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "10"
 
-sudo: false
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable
@@ -20,35 +19,34 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
 
+branches:
+  only:
+    - master
+    # npm version tags
+    - /^v\d+\.\d+\.\d+/
+
 jobs:
-  fail_fast: true
+  fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
   include:
     # runs linting and tests with current locked deps
-
     - stage: "Tests"
       name: "Tests"
       script:
-        - npm run lint:hbs
-        - npm run lint:js
+        - npm lint
         - npm test
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.16
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.20
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
-
-before_install:
-  - npm config set spin false
-  - npm install -g npm@4
-  - npm --version
+    - env: EMBER_TRY_SCENARIO=ember-classic
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# How To Contribute
+
+## Installation
+
+* `git clone <repository-url>`
+* `cd @storybook/ember-cli-storybook`
+* `yarn install`
+
+## Linting
+
+* `yarn lint:hbs`
+* `yarn lint:js`
+* `yarn lint:js --fix`
+
+## Running tests
+
+* `ember test` – Runs the test suite on the current Ember version
+* `ember test --server` – Runs the test suite in "watch mode"
+* `ember try:each` – Runs the test suite against multiple Ember versions
+
+## Running the dummy application
+
+* `ember serve`
+* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
+
+For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ ember-cli-storybook
 
 📒 Ember storybook adapter
 
+
+Compatibility
+------------------------------------------------------------------------------
+
+* Ember.js v3.16 or above
+* Ember CLI v2.13 or above
+* Node.js v10 or above
+
+
 Installation
 ------------------------------------------------------------------------------
 
@@ -172,6 +181,8 @@ export let Standard = () => {
   };
 };
 ```
+
+See the [Contributing](CONTRIBUTING.md) guide for details.
 
 License
 ------------------------------------------------------------------------------

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const getChannelURL = require('ember-source-channel-url');
+
+module.exports = async function() {
+  return {
+    useYarn: true,
+    scenarios: [
+      {
+        name: 'ember-lts-3.16',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.16.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.5'
+          }
+        }
+      },
+      {
+        name: 'ember-release',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('release')
+          }
+        }
+      },
+      {
+        name: 'ember-beta',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('beta')
+          }
+        }
+      },
+      {
+        name: 'ember-canary',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('canary')
+          }
+        }
+      },
+      {
+        name: 'ember-default-with-jquery',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({
+            'jquery-integration': true
+          })
+        },
+        npm: {
+          devDependencies: {
+            '@ember/jquery': '^1.1.0'
+          }
+        }
+      },
+      {
+        name: 'ember-classic',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({
+            'application-template-wrapper': true,
+            'default-async-observers': false,
+            'template-only-glimmer-components': false
+          })
+        },
+        npm: {
+          ember: {
+            edition: 'classic'
+          }
+        }
+      }
+    ]
+  };
+};

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const mergeTrees = require('broccoli-merge-trees');
 const { parse, generatePreviewHead } = require('./util');
 
 module.exports = {
-  name: 'ember-cli-storybook',
+  name: require('./package').name,
 
   _getOptions() {
     let addonOptions = (this.parent && this.parent.options) || (this.app && this.app.options) || {};
@@ -70,6 +70,7 @@ module.exports = {
     const distFilePath = path.resolve(result.directory, 'index.html');
     const testFilePath = path.resolve(result.directory, 'tests/index.html');
     const previewHeadFilePath = path.resolve(process.cwd(), '.storybook/preview-head.html');
+    const previewHeadDirectory = path.dirname(previewHeadFilePath);
     const envFilePath = path.resolve(process.cwd(), '.env');
 
     let fileContents = '';
@@ -94,7 +95,8 @@ module.exports = {
 
     this.ui.writeLine('Generating files needed by Storybook');
 
-    fs.writeFileSync(previewHeadFilePath, previewHead)
+    fs.mkdirSync(previewHeadDirectory, { recursive: true });
+    fs.writeFileSync(previewHeadFilePath, previewHead);
 
     this.ui.writeLine('Generating .env');
 

--- a/node-tests/util.js
+++ b/node-tests/util.js
@@ -31,31 +31,31 @@ test('@parse', (t) => {
       }],
       link: [{
           rel: 'stylesheet',
-          href: '/assets/vendor.css'
+          href: './assets/vendor.css'
         },
         {
           rel: 'stylesheet',
-          href: '/assets/storybook-ember-3-1.css'
+          href: './assets/storybook-ember-3-1.css'
         },
         {
           rel: 'stylesheet',
-          href: '/assets/test-support.css'
+          href: './assets/test-support.css'
         }
       ],
       script: [{
-          src: '/testem.js'
+          src: './testem.js'
         },
         {
-          src: '/assets/vendor.js'
+          src: './assets/vendor.js'
         },
         {
-          src: '/assets/test-support.js'
+          src: './assets/test-support.js'
         },
         {
-          src: '/assets/storybook-ember-3-1.js'
+          src: './assets/storybook-ember-3-1.js'
         },
         {
-          src: '/assets/tests.js'
+          src: './assets/tests.js'
         }
       ]
     });
@@ -73,26 +73,26 @@ test('@parse', (t) => {
         content: '%7B%22modulePrefix%22%3A%22vault%22%2C%22environment%22%3A%22development%22%2C%22rootURL%22%3A%22/ui/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22POLLING_URLS%22%3A%5B%22sys/health%22%2C%22sys/replication/status%22%2C%22sys/seal-status%22%5D%2C%22NAMESPACE_ROOT_URLS%22%3A%5B%22sys/health%22%2C%22sys/seal-status%22%2C%22sys/license/features%22%5D%2C%22DEFAULT_PAGE_SIZE%22%3A15%2C%22LOG_TRANSITIONS%22%3Atrue%7D%2C%22flashMessageDefaults%22%3A%7B%22timeout%22%3A7000%2C%22sticky%22%3Afalse%2C%22preventDuplicates%22%3Atrue%7D%2C%22contentSecurityPolicyHeader%22%3A%22Content-Security-Policy%22%2C%22contentSecurityPolicyMeta%22%3Atrue%2C%22contentSecurityPolicy%22%3A%7B%22connect-src%22%3A%5B%22%27self%27%22%5D%2C%22img-src%22%3A%5B%22%27self%27%22%2C%22data%3A%22%5D%2C%22form-action%22%3A%5B%22%27none%27%22%5D%2C%22script-src%22%3A%5B%22%27self%27%22%5D%2C%22style-src%22%3A%5B%22%27unsafe-inline%27%22%2C%22%27self%27%22%5D%2C%22default-src%22%3A%5B%22%27none%27%22%5D%2C%22font-src%22%3A%5B%22%27self%27%22%5D%2C%22media-src%22%3A%5B%22%27self%27%22%5D%7D%2C%22emberData%22%3A%7B%22enableRecordDataRFCBuild%22%3Afalse%7D%2C%22exportApplicationGlobal%22%3Atrue%7D' }],
       link: [{
           rel: 'stylesheet',
-          href: '/assets/vendor.css'
+          href: './assets/vendor.css'
         },
         {
           rel: 'stylesheet',
-          href: '/assets/vault.css'
+          href: './assets/vault.css'
         },
         {
           rel: 'icon',
-          href: '/favicon.png'
+          href: './favicon.png'
         }
       ],
       script: [
         {
-          src: '/ember-cli-live-reload.js'
+          src: './ember-cli-live-reload.js'
         },
         {
-          src: '/assets/vendor.js'
+          src: './assets/vendor.js'
         },
         {
-          src: '/assets/vault.js'
+          src: './assets/vault.js'
         },
       ]
     });
@@ -110,21 +110,21 @@ test('@parse', (t) => {
       }],
       link: [{
           rel: 'stylesheet',
-          href: '/assets/vendor.css'
+          href: './assets/vendor.css'
         },
         {
           rel: 'stylesheet',
-          href: '/assets/storybook-ember-3-1.css'
+          href: './assets/storybook-ember-3-1.css'
         }
       ],
       script: [{
-          src: '/testem.js'
+          src: './testem.js'
         },
         {
-          src: '/assets/vendor.js'
+          src: './assets/vendor.js'
         },
         {
-          src: '/assets/storybook-ember-3-1.js'
+          src: './assets/storybook-ember-3-1.js'
         }
       ]
     });
@@ -155,7 +155,7 @@ test('@generatePreviewHead', (t) => {
 
     const fileContent = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'build.html'), 'utf8');
 
-    t.deepEqual(generatePreviewHead(parse(fileContent)), `<meta name="storybook-ember-3-1/config/environment" content="%7B%22modulePrefix%22%3A%22storybook-ember-3-1%22%2C%22environment%22%3A%22test%22%2C%22rootURL%22%3A%22/%22%2C%22locationType%22%3A%22none%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22LOG_ACTIVE_GENERATION%22%3Afalse%2C%22LOG_VIEW_LOOKUPS%22%3Afalse%2C%22rootElement%22%3A%22%23ember-testing%22%2C%22autoboot%22%3Afalse%2C%22name%22%3A%22storybook-ember-3-1%22%2C%22version%22%3A%220.0.0+eebe77e5%22%7D%2C%22exportApplicationGlobal%22%3Atrue%7D" />\n<link rel="stylesheet" href="/assets/vendor.css" />\n<link rel="stylesheet" href="/assets/storybook-ember-3-1.css" />\n<link rel="stylesheet" href="/assets/test-support.css" />\n<script src="/testem.js"></script>\n<script>runningTests = true;</script>\n<script src="/assets/vendor.js"></script>\n<script src="/assets/test-support.js"></script>\n<script src="/assets/storybook-ember-3-1.js"></script>\n<script src="/assets/tests.js"></script>`);
+    t.deepEqual(generatePreviewHead(parse(fileContent)), `<!-- This file is auto-generated by ember-cli-storybook -->\n<meta name="storybook-ember-3-1/config/environment" content="%7B%22modulePrefix%22%3A%22storybook-ember-3-1%22%2C%22environment%22%3A%22test%22%2C%22rootURL%22%3A%22/%22%2C%22locationType%22%3A%22none%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22LOG_ACTIVE_GENERATION%22%3Afalse%2C%22LOG_VIEW_LOOKUPS%22%3Afalse%2C%22rootElement%22%3A%22%23ember-testing%22%2C%22autoboot%22%3Afalse%2C%22name%22%3A%22storybook-ember-3-1%22%2C%22version%22%3A%220.0.0+eebe77e5%22%7D%2C%22exportApplicationGlobal%22%3Atrue%7D" />\n<link rel="stylesheet" href="./assets/vendor.css" />\n<link rel="stylesheet" href="./assets/storybook-ember-3-1.css" />\n<link rel="stylesheet" href="./assets/test-support.css" />\n<script src="./testem.js"></script>\n<script src="./assets/vendor.js"></script>\n<script>runningTests = true; Ember.testing=true;</script>\n<script src="./assets/test-support.js"></script>\n<script src="./assets/storybook-ember-3-1.js"></script>\n<script src="./assets/tests.js"></script>`);
   })
 
   t.test('should work with file created with `ember serve` (should append livereload pointing at serve instance)', (t) => {
@@ -163,6 +163,6 @@ test('@generatePreviewHead', (t) => {
 
     const fileContent = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'serve.html'), 'utf8');
 
-    t.deepEqual(generatePreviewHead(parse(fileContent)), `<meta name="storybook-ember-3-1/config/environment" content="%7B%22modulePrefix%22%3A%22storybook-ember-3-1%22%2C%22environment%22%3A%22test%22%2C%22rootURL%22%3A%22/%22%2C%22locationType%22%3A%22none%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22LOG_ACTIVE_GENERATION%22%3Afalse%2C%22LOG_VIEW_LOOKUPS%22%3Afalse%2C%22rootElement%22%3A%22%23ember-testing%22%2C%22autoboot%22%3Afalse%2C%22name%22%3A%22storybook-ember-3-1%22%2C%22version%22%3A%220.0.0+eebe77e5%22%7D%2C%22exportApplicationGlobal%22%3Atrue%7D" />\n<link rel="stylesheet" href="/assets/vendor.css" />\n<link rel="stylesheet" href="/assets/storybook-ember-3-1.css" />\n<link rel="stylesheet" href="/assets/test-support.css" />\n<script>\n            (function() {\n              var srcUrl = null;\n              var host = location.hostname || 'localhost';\n              var defaultPort = location.protocol === 'https:' ? 443 : 80;\n              var port = undefined;\n              var path = '';\n              var prefixURL = '';\n              var src = srcUrl || prefixURL + '/_lr/livereload.js?port=' + port + '&host=' + host + path;\n              var script = document.createElement('script');\n              script.type = 'text/javascript';\n              script.src = location.protocol + '//' + host + ':undefined' + src;\n              document.getElementsByTagName('head')[0].appendChild(script);\n            }());\n          </script>\n<script src="/testem.js"></script>\n<script>runningTests = true;</script>\n<script src="/assets/vendor.js"></script>\n<script src="/assets/test-support.js"></script>\n<script src="/assets/storybook-ember-3-1.js"></script>\n<script src="/assets/tests.js"></script>`);
+    t.deepEqual(generatePreviewHead(parse(fileContent)), `<!-- This file is auto-generated by ember-cli-storybook -->\n<meta name="storybook-ember-3-1/config/environment" content="%7B%22modulePrefix%22%3A%22storybook-ember-3-1%22%2C%22environment%22%3A%22test%22%2C%22rootURL%22%3A%22/%22%2C%22locationType%22%3A%22none%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22LOG_ACTIVE_GENERATION%22%3Afalse%2C%22LOG_VIEW_LOOKUPS%22%3Afalse%2C%22rootElement%22%3A%22%23ember-testing%22%2C%22autoboot%22%3Afalse%2C%22name%22%3A%22storybook-ember-3-1%22%2C%22version%22%3A%220.0.0+eebe77e5%22%7D%2C%22exportApplicationGlobal%22%3Atrue%7D" />\n<link rel="stylesheet" href="./assets/vendor.css" />\n<link rel="stylesheet" href="./assets/storybook-ember-3-1.css" />\n<link rel="stylesheet" href="./assets/test-support.css" />\n<script>\n            (function() {\n              var srcUrl = null;\n              var host = location.hostname || 'localhost';\n              var defaultPort = location.protocol === 'https:' ? 443 : 80;\n              var port = undefined;\n              var path = '';\n              var prefixURL = '';\n              var src = srcUrl || prefixURL + '/_lr/livereload.js?port=' + port + '&host=' + host + path;\n              var script = document.createElement('script');\n              script.type = 'text/javascript';\n              script.src = location.protocol + '//' + host + ':undefined' + src;\n              document.getElementsByTagName('head')[0].appendChild(script);\n            }());\n          </script>\n<script src="./testem.js"></script>\n<script src="./assets/vendor.js"></script>\n<script>runningTests = true; Ember.testing=true;</script>\n<script src="./assets/test-support.js"></script>\n<script src="./assets/storybook-ember-3-1.js"></script>\n<script src="./assets/tests.js"></script>`);
   });
 });

--- a/package.json
+++ b/package.json
@@ -21,43 +21,48 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build",
-    "lint": "eslint .",
+    "build": "ember build --environment=production",
+    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
+    "lint:js": "eslint .",
     "start": "ember serve",
-    "test": "tape node-tests/**.js",
-    "test:all": "ember try:each"
+    "test": "npm-run-all lint:* test:*",
+    "test:node": "tape node-tests/**.js",
+    "test:ember": "ember test",
+    "test:ember-compatibility": "ember try:each"
   },
   "devDependencies": {
-    "@ember/optional-features": "^0.6.3",
-    "broccoli-asset-rev": "^2.7.0",
-    "broccoli-merge-trees": "^3.0.2",
-    "ember-ajax": "^3.1.0",
-    "ember-cli": "~3.5.0-beta.1",
-    "ember-cli-dependency-checker": "^3.0.0",
-    "ember-cli-eslint": "^4.2.3",
-    "ember-cli-htmlbars": "^3.0.0",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.3",
-    "ember-cli-inject-live-reload": "^1.8.2",
-    "ember-cli-qunit": "^4.3.2",
+    "@ember/optional-features": "^1.3.0",
+    "babel-eslint": "^10.1.0",
+    "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.6.0",
+    "ember-cli": "~3.20.2",
+    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-template-lint": "^1.0.0-beta.1",
-    "ember-cli-uglify": "^2.1.0",
+    "ember-cli-uglify": "^3.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
-    "ember-export-application-global": "^2.0.0",
-    "ember-load-initializers": "^1.1.0",
+    "ember-export-application-global": "^2.0.1",
+    "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-resolver": "^5.0.1",
-    "ember-source": "~3.5.0-beta.1",
-    "ember-source-channel-url": "^1.1.0",
-    "ember-try": "^1.0.0",
-    "eslint-plugin-ember": "^5.2.0",
-    "eslint-plugin-node": "^7.0.1",
+    "ember-qunit": "^4.6.0",
+    "ember-resolver": "^8.0.0",
+    "ember-source": "~3.20.2",
+    "ember-source-channel-url": "^2.0.1",
+    "ember-template-lint": "^2.9.1",
+    "ember-try": "^1.4.0",
+    "eslint": "^7.5.0",
+    "eslint-plugin-ember": "^8.9.1",
+    "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
-    "qunit-dom": "^0.7.1",
+    "npm-run-all": "^4.1.5",
+    "qunit-dom": "^1.2.0",
     "tape": "^4.9.1"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "10.* || >= 12"
+  },
+  "ember": {
+    "edition": "octane"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
@@ -65,9 +70,11 @@
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.2",
+    "broccoli-merge-trees": "^3.0.2",
     "cheerio": "^1.0.0-rc.2",
     "ember-cli-addon-docs-yuidoc": "^0.2.3",
-    "ember-cli-babel": "^7.1.2"
+    "ember-cli-babel": "^7.23.0",
+    "ember-cli-htmlbars": "^5.3.1"
   },
   "publishConfig": {
     "access": "public"

--- a/testem.js
+++ b/testem.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
@@ -7,13 +9,13 @@ module.exports = {
   launch_in_dev: [
     'Chrome'
   ],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,14 +1,12 @@
 import Application from '@ember/application';
-import Resolver from './resolver';
+import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
-import config from './config/environment';
+import config from 'dummy/config/environment';
 
-const App = Application.extend({
-  modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix,
-  Resolver
-});
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
 
 loadInitializers(App, config.modulePrefix);
-
-export default App;

--- a/tests/dummy/app/resolver.js
+++ b/tests/dummy/app/resolver.js
@@ -1,3 +1,0 @@
-import Resolver from 'ember-resolver';
-
-export default Resolver;

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,12 +1,10 @@
 import EmberRouter from '@ember/routing/router';
-import config from './config/environment';
+import config from 'dummy/config/environment';
 
-const Router = EmberRouter.extend({
-  location: config.locationType,
-  rootURL: config.rootURL
-});
+export default class Router extends EmberRouter {
+  location = config.locationType;
+  rootURL = config.rootURL;
+}
 
 Router.map(function() {
 });
-
-export default Router;

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -9,7 +9,7 @@ module.exports = function(environment) {
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
-        // e.g. 'with-controller': true
+        // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,3 +1,6 @@
 {
-  "jquery-integration": false
+  "application-template-wrapper": false,
+  "default-async-observers": true,
+  "jquery-integration": false,
+  "template-only-glimmer-components": true
 }

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -6,7 +6,7 @@ const browsers = [
   'last 1 Safari versions'
 ];
 
-const isCI = !!process.env.CI;
+const isCI = Boolean(process.env.CI);
 const isProduction = process.env.EMBER_ENV === 'production';
 
 if (isCI || isProduction) {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,5 +1,5 @@
-import Application from '../app';
-import config from '../config/environment';
+import Application from 'dummy/app';
+import config from 'dummy/config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 


### PR DESCRIPTION
Hi 👋 

Based on conversation in https://github.com/storybookjs/storybook/pull/13142#discussion_r525063399 I was hoping to add `renderStory()` as a test utility

While putting together that PR, I went to write tests and noticed that this addon is quite outdated.

I've run `ember-cli-update --to 3.20`, which is the current LTS version, and amended a few things when needed, which I've left comments for 👇 

https://github.com/ember-cli/ember-addon-output is also a good resource 👀 