### PR TITLE
[bug] fixes defaultBlueprint path to point to scoped package path

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "defaultBlueprint": "ember-cli-storybook"
+    "defaultBlueprint": "@storybook/ember-cli-storybook"
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.2",


### PR DESCRIPTION
fixes #12 #55 by fixing the package name described in defaultBlueprint to point to the new scoped package name.