### PR TITLE
🔧 add CI configuration for Ember try & lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [12.x, 14.x]
@@ -21,4 +19,36 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: npm test
+    - run: npm run test:ember
+
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run lint
+
+  ember-try:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 12.x, 14.x ]
+        ember: [lts-3.20, lts-3.16, release, beta, canary, default-with-jquery, classic]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests for ember-${{ matrix.ember }}
+        run: ./node_modules/.bin/ember try:one ember-${{ matrix.ember }}


### PR DESCRIPTION
This PR aims to add lint job to each pull request to ease review. 
Also add `ember try` on lts-3.20, lts-3.18, release, beta, canary

I've also splitted each job into smaller one, to avoid running one massive `npm run test*`

Next steps: 
- add more tests (we currently have 4) 😁
- add hbs linter 
- prettier?
- add dependency linter

Resolves partially #58 