### PR TITLE
Allow environment overrides specifically for Storybook

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,5 @@
 const cheerio = require('cheerio');
+const merge = require('lodash.merge');
 
 const lookupTable = {
   meta: [{
@@ -156,9 +157,14 @@ function generatePreviewHead(parsedConfig) {
   return doc.join('\n')
 }
 
+function overrideEnvironment(env, ...overrides) {
+  return merge(env, ...overrides);
+}
+
 module.exports = {
   getDocumentValues,
   parse,
   objectToHTMLAttributes,
   generatePreviewHead,
+  overrideEnvironment,
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -157,8 +157,20 @@ function generatePreviewHead(parsedConfig) {
   return doc.join('\n')
 }
 
-function overrideEnvironment(env, ...overrides) {
-  return merge(env, ...overrides);
+function extendEnvironment(env, ...extensions) {
+  return merge(env, ...extensions);
+}
+
+// Given a parsed config, returns the `config/environment` meta node
+function findEnvironment(parsedConfig) {
+  return parsedConfig.meta.find(meta => meta.name.endsWith('config/environment'));
+}
+
+// In-place mutation of the env meta node to include encoded extensions
+function overrideEnvironment(env, ...extensions) {
+  // From the Ember App's environment.js file
+  const original = JSON.parse(decodeURIComponent(env.content));
+  return encodeURIComponent(JSON.stringify(extendEnvironment(original, ...extensions)));
 }
 
 module.exports = {
@@ -166,5 +178,7 @@ module.exports = {
   parse,
   objectToHTMLAttributes,
   generatePreviewHead,
+  findEnvironment,
+  extendEnvironment,
   overrideEnvironment,
 };

--- a/node-tests/fixtures/no-env.html
+++ b/node-tests/fixtures/no-env.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>StorybookEmber31 Tests</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- no environment meta element here -->
+    <script src="/ember-cli-live-reload.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="/assets/vendor.css">
+    <link rel="stylesheet" href="/assets/storybook-ember-3-1.css">
+    <link rel="stylesheet" href="/assets/test-support.css">
+
+
+
+  </head>
+  <body>
+
+    <div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="ember-testing-container">
+  <div id="ember-testing"></div>
+</div>
+
+    <script src="/testem.js" integrity=""></script>
+    <script src="/assets/vendor.js"></script>
+    <script src="/assets/test-support.js"></script>
+    <script src="/assets/storybook-ember-3-1.js"></script>
+    <script src="/assets/tests.js"></script>
+
+    <script type="module" src="/assets/component.js"></script>
+
+
+    <script>Ember.assert('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".', EmberENV.TESTS_FILE_LOADED);</script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "cheerio": "^1.0.0-rc.10",
     "ember-cli-addon-docs-yuidoc": "^1.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-htmlbars": "^6.0.1"
+    "ember-cli-htmlbars": "^6.0.1",
+    "lodash.merge": "^4.6.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Stories are rendered as full Ember Apps including the default environment, which may have settings that aren't appropriate for only rendering a single story in an iframe.

This makes it so settings in `environment.js` can be overridden by settings in `.storybook/environment.js`.

It also resets `rootURL` to `/` (after doing the existing `rootURL` resource transformations) since Ember doesn't at all like running the router in an iframe when `rootURL` is anything other than `/`.