### PR TITLE
Maintain `type` attribute on script tags

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -17,7 +17,7 @@ const lookupTable = {
   }],
   script: [{
     selector: 'script',
-    attributes: ['src']
+    attributes: ['src', 'type']
   }]
 };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -16,7 +16,10 @@ const lookupTable = {
     attributes: ['rel', 'href']
   }],
   script: [{
-    selector: 'script',
+    selector: 'script:not([type])',
+    attributes: ['src']
+  }, {
+    selector: 'script[type]',
     attributes: ['src', 'type']
   }]
 };

--- a/node-tests/__snapshots__/util.test.js.snap
+++ b/node-tests/__snapshots__/util.test.js.snap
@@ -11,7 +11,8 @@ exports[`util @generatePreviewHead should work with file created with \`ember bu
 <script>runningTests = true; Ember.testing=true;</script>
 <script src=\\"./assets/test-support.js\\"></script>
 <script src=\\"./assets/storybook-ember-3-1.js\\"></script>
-<script src=\\"./assets/tests.js\\"></script>"
+<script src=\\"./assets/tests.js\\"></script>
+<script src=\\"./assets/component.js\\" type=\\"module\\"></script>"
 `;
 
 exports[`util @generatePreviewHead should work with file created with \`ember serve\` (should append livereload pointing at serve instance) 1`] = `
@@ -20,6 +21,12 @@ exports[`util @generatePreviewHead should work with file created with \`ember se
 <link rel=\\"stylesheet\\" href=\\"./assets/vendor.css\\" />
 <link rel=\\"stylesheet\\" href=\\"./assets/storybook-ember-3-1.css\\" />
 <link rel=\\"stylesheet\\" href=\\"./assets/test-support.css\\" />
+<script src=\\"./testem.js\\"></script>
+<script src=\\"./assets/vendor.js\\"></script>
+<script>runningTests = true; Ember.testing=true;</script>
+<script src=\\"./assets/test-support.js\\"></script>
+<script src=\\"./assets/storybook-ember-3-1.js\\"></script>
+<script src=\\"./assets/tests.js\\"></script>
 <script>
             (function() {
               var srcUrl = null;
@@ -35,12 +42,7 @@ exports[`util @generatePreviewHead should work with file created with \`ember se
               document.getElementsByTagName('head')[0].appendChild(script);
             }());
           </script>
-<script src=\\"./testem.js\\"></script>
-<script src=\\"./assets/vendor.js\\"></script>
-<script>runningTests = true; Ember.testing=true;</script>
-<script src=\\"./assets/test-support.js\\"></script>
-<script src=\\"./assets/storybook-ember-3-1.js\\"></script>
-<script src=\\"./assets/tests.js\\"></script>"
+<script src=\\"./assets/component.js\\" type=\\"module\\"></script>"
 `;
 
 exports[`util @parse should be able to parse metas from a built html file from an app that uses engines 1`] = `

--- a/node-tests/fixtures/build.html
+++ b/node-tests/fixtures/build.html
@@ -32,6 +32,8 @@
     <script src="/assets/storybook-ember-3-1.js"></script>
     <script src="/assets/tests.js"></script>
 
+    <script type="module" src="/assets/component.js"></script>
+
 
     <script>Ember.assert('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".', EmberENV.TESTS_FILE_LOADED);</script>
   </body>

--- a/node-tests/fixtures/serve.html
+++ b/node-tests/fixtures/serve.html
@@ -34,6 +34,8 @@
     <script src="/assets/storybook-ember-3-1.js"></script>
     <script src="/assets/tests.js"></script>
 
+    <script type="module" src="/assets/component.js"></script>
+
 
     <script>Ember.assert('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".', EmberENV.TESTS_FILE_LOADED);</script>
   </body>

--- a/node-tests/util.test.js
+++ b/node-tests/util.test.js
@@ -62,6 +62,10 @@ Object {
     Object {
       "src": "./assets/tests.js",
     },
+    Object {
+      "src": "./assets/component.js",
+      "type": "module",
+    },
   ],
 }
 `);
@@ -101,9 +105,6 @@ Object {
   ],
   "script": Array [
     Object {
-      "src": "./ember-cli-live-reload.js",
-    },
-    Object {
       "src": "./assets/vendor.js",
     },
     Object {
@@ -111,6 +112,10 @@ Object {
     },
     Object {
       "src": "http://example.com/external/script.js",
+    },
+    Object {
+      "src": "./ember-cli-live-reload.js",
+      "type": "text/javascript",
     },
   ],
 }
@@ -149,6 +154,10 @@ Object {
     },
     Object {
       "src": "./assets/storybook-ember-3-1.js",
+    },
+    Object {
+      "src": "./assets/component.js",
+      "type": "module",
     },
   ],
 }


### PR DESCRIPTION
When updating `preview-head.html` with content from `index.html` script
tags include only the `src` attribute; other attributes are stripped
out. This change ensures the `type` attribute is included as well
as `src`.