### PR TITLE
fix: do nothing if no meta found in removeRootURL()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -57,6 +57,7 @@ function escape(string) {
 }
 
 function removeRootURL(config) {
+  if(!config.meta.length) return config;
   // extract and parse the application config
   let appConfig = JSON.parse(decodeURIComponent(config.meta[0].content));
   let { rootURL } = appConfig;


### PR DESCRIPTION
This fixes https://github.com/storybookjs/ember-cli-storybook/issues/42 