### PR TITLE
Handle src-less script tags without error

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -68,10 +68,16 @@ function removeRootURL(config) {
 
   let pattern = new RegExp(`^${escape(rootURL)}`);
 
-  config.script = config.script.map(s => {
-    s.src = s.src.replace(pattern, './');
-    return s;
-  });
+  config.script = config.script.reduce((accumulator, s) => {
+    // This ensures we don't hit an error when there is a script tag
+    // with a `type` but without a `src`
+    if (s.src) {
+      s.src = s.src.replace(pattern, './');
+      accumulator.push(s);
+    }
+
+    return accumulator;
+  }, []);
   config.link = config.link.map(l => {
     l.href = l.href.replace(pattern, './');
     return l;

--- a/node-tests/fixtures/build.html
+++ b/node-tests/fixtures/build.html
@@ -33,6 +33,7 @@
     <script src="/assets/tests.js"></script>
 
     <script type="module" src="/assets/component.js"></script>
+    <script type="text/javascript">console.log('test');</script>
 
 
     <script>Ember.assert('The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".', EmberENV.TESTS_FILE_LOADED);</script>


### PR DESCRIPTION
After #96, any script tag with a `type` but without ` src` will cause a build error. This fixes that case.

Edit: Tests pass locally, but because this addon isn't compatible with Ember 4.0, the ember-try scenarios fail.