### PR TITLE
Include all `meta` tags

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,13 +2,7 @@ const cheerio = require('cheerio');
 
 const lookupTable = {
   meta: [{
-    selector: 'meta[name*="/config/environment"]',
-    attributes: ['name', 'content']
-  }, {
-    selector: 'meta[name*="/config/asset-manifest"]',
-    attributes: ['name', 'content']
-  }, {
-    selector: 'meta[id]',
+    selector: 'meta',
     attributes: ['name', 'content', 'id']
   }],
   link: [{
@@ -34,17 +28,13 @@ function getDocumentValues($, selector, attributes=[], ignoreRegexs=[]) {
     var data = attributes.reduce(function(data, attribute) {
       const value = $tag.attr(attribute);
 
-      let ignored = false;
-
       if(value && !ignoreRegexs.find((regex) => {
         return regex.exec(value)
       })) {
         data[attribute] = value
-      } else {
-        ignored = true;
       }
 
-      return ignored ? {} : data;
+      return data;
     }, {})
 
     if(Object.keys(data).length > 0) {
@@ -62,7 +52,12 @@ function escape(string) {
 function removeRootURL(config) {
   if(!config.meta.length) return config;
   // extract and parse the application config
-  let appConfig = JSON.parse(decodeURIComponent(config.meta[0].content));
+
+  const configTag = config.meta.find(tag => {
+    return tag.name && tag.name.match('config/environment') ? tag : false
+  });
+
+  let appConfig = JSON.parse(decodeURIComponent(configTag.content));
   let { rootURL } = appConfig;
   if (!rootURL) return config;
 
@@ -72,10 +67,13 @@ function removeRootURL(config) {
     s.src = s.src.replace(pattern, './');
     return s;
   });
-  config.link = config.link.map(l => {
-    l.href = l.href.replace(pattern, './');
-    return l;
-  });
+  config.link = config.link.reduce((accumulator, l) => {
+    if (l.href) {
+      l.href = l.href.replace(pattern, './');
+      accumulator.push(l);
+    }
+    return accumulator;
+  }, []);
   return config;
 }
 


### PR DESCRIPTION
If users of this addon want to include their own `meta` tags, it would either require modifying the config so that users could add to the `lookupTable` or include all `meta` tags when parsing.

Tests will fail since I haven't updated the snapshots to reflect the new tags, but wanted to discuss this approach before I did that.