### PR TITLE
chore: bump node minimum to 16 and adds docs about ember configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 12.x, 14.x ]
+        node-version: [ 16.x ]
         ember: [lts-3.20, lts-3.16, release, beta, canary, default-with-jquery, classic]
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Unreleased
+
 # 0.5.0 (04/09/2021)
 
 - [feature - enable config overrides](https://github.com/storybookjs/ember-cli-storybook/pull/80)

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 * Ember.js v3.16 or above
 * Ember CLI v2.13 or above
-* Node.js v10 or above
+* Node.js v16 or above
 
 # Installation
 
-```terminal
+```shell
 ember install @storybook/ember-cli-storybook
 ```
 
@@ -25,6 +25,15 @@ This will be triggered automatically as a post build action when running `ember 
 "storybook": {
   "ignoreTestFiles": true,
   "config": {}
+}
+```
+
+> ember-cli-build options (defaults)
+
+```json
+"ember-cli-storybook": {
+  "componentFilePathPatterns": [],
+  "enableAddonDocsIntegration": true, // enables yuidoc generation
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = {
     let componentJS = new Funnel('.', {
       include: componentFilePathPatterns,
     });
+
     let componentDocsTree = new YUIDocsGenerator([componentJS], {
       project: this.project,
       destDir: 'storybook-docgen',

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.6.0",
-    "ember-cli": "~3.26.1",
+    "ember-cli": "~3.28.3",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
@@ -46,7 +46,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.5",
+    "ember-source": "~3.28.8",
     "ember-source-channel-url": "^2.0.1",
     "ember-template-lint": "^3.4.2",
     "ember-try": "^1.4.0",
@@ -54,13 +54,13 @@
     "eslint-plugin-ember": "^8.9.1",
     "eslint-plugin-jest": "^24.4.0",
     "eslint-plugin-node": "^11.1.0",
-    "jest": "^27.0.6",
+    "jest": "^27.5.1",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "qunit-dom": "^1.2.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": ">= 16"
   },
   "ember": {
     "edition": "octane"
@@ -72,10 +72,10 @@
   "dependencies": {
     "broccoli-funnel": "^3.0.8",
     "broccoli-merge-trees": "^4.2.0",
-    "cheerio": "^1.0.0-rc.2",
+    "cheerio": "^1.0.0-rc.10",
     "ember-cli-addon-docs-yuidoc": "^1.0.0",
-    "ember-cli-babel": "^7.23.0",
-    "ember-cli-htmlbars": "^5.3.1"
+    "ember-cli-babel": "^7.26.11",
+    "ember-cli-htmlbars": "^6.0.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
fixes #107 

Adds documentation around ember configuration options with recent yuidoc failure. 

Bumps dependencies and node version.