### PR TITLE
Add check for src-less scripts in preview

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -118,7 +118,7 @@ function generatePreviewHead(parsedConfig) {
   for(const key of Object.keys(parsedConfig)) {
     for(const value of parsedConfig[key]) {
       if(key == 'script') {
-        if(value.src.indexOf('ember-cli-live-reload.js') > -1) {
+        if(value.src && value.src.indexOf('ember-cli-live-reload.js') > -1) {
           doc.push(`<script>
             (function() {
               var srcUrl = null;
@@ -137,7 +137,7 @@ function generatePreviewHead(parsedConfig) {
           continue;
         }
         doc.push(`<${key} ${objectToHTMLAttributes(value)}></${key}>`);
-        if(value.src.indexOf('assets/vendor.js') > -1) {
+        if(value.src && value.src.indexOf('assets/vendor.js') > -1) {
           // make sure we push this right after vendor to ensure the application does not bind to the window.
           doc.push('<script>runningTests = true; Ember.testing=true;</script>');
         }


### PR DESCRIPTION
My app uses `ember-cli-segment`, which adds a script tag (something similar to a Google Analytics tag) to my HTML. It ends up in the preview with a `<script type="text/javascript">` tag. The build fails with a `Cannot read property 'indexOf' of undefined` error on line 121 here, then on line 140 once that's fixed. This PR adds checks to avoid calling `indexOf` on script tags without `src` attributes.

I looked at the test and I'm not sure how you'd want to test it? I imagine the existing tests might fail if a `Object { "type": "text/javascript", },` is added, but now they'll pass?

Thanks.