### PR TITLE
Set window.Ember in preview-head.html. Closes #103

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16.x ]
-        ember: [lts-3.20, lts-3.16, release, beta, canary, default-with-jquery, classic]
+        ember: [lts-3.28, lts-3.24, 4.1, release, beta, canary, default-with-jquery, classic]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/lib/util.js
+++ b/lib/util.js
@@ -145,7 +145,7 @@ function generatePreviewHead(parsedConfig) {
         doc.push(`<${key} ${objectToHTMLAttributes(value)}></${key}>`);
         if(value.src.indexOf('assets/vendor.js') > -1) {
           // make sure we push this right after vendor to ensure the application does not bind to the window.
-          doc.push('<script>runningTests = true; Ember.testing=true;</script>');
+          doc.push('<script>window.Ember = require("ember").default; runningTests = true; Ember.testing=true;</script>');
         }
       } else {
         doc.push(`<${key} ${objectToHTMLAttributes(value)} />`);

--- a/node-tests/__snapshots__/util.test.js.snap
+++ b/node-tests/__snapshots__/util.test.js.snap
@@ -8,7 +8,7 @@ exports[`util @generatePreviewHead should work with file created with \`ember bu
 <link rel=\\"stylesheet\\" href=\\"./assets/test-support.css\\" />
 <script src=\\"./testem.js\\"></script>
 <script src=\\"./assets/vendor.js\\"></script>
-<script>runningTests = true; Ember.testing=true;</script>
+<script>window.Ember = require(\\"ember\\").default; runningTests = true; Ember.testing=true;</script>
 <script src=\\"./assets/test-support.js\\"></script>
 <script src=\\"./assets/storybook-ember-3-1.js\\"></script>
 <script src=\\"./assets/tests.js\\"></script>
@@ -23,7 +23,7 @@ exports[`util @generatePreviewHead should work with file created with \`ember se
 <link rel=\\"stylesheet\\" href=\\"./assets/test-support.css\\" />
 <script src=\\"./testem.js\\"></script>
 <script src=\\"./assets/vendor.js\\"></script>
-<script>runningTests = true; Ember.testing=true;</script>
+<script>window.Ember = require(\\"ember\\").default; runningTests = true; Ember.testing=true;</script>
 <script src=\\"./assets/test-support.js\\"></script>
 <script src=\\"./assets/storybook-ember-3-1.js\\"></script>
 <script src=\\"./assets/tests.js\\"></script>

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
+    "@ember/test-helpers": "^2.8.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "ember-auto-import": "^1.6.0",
+    "ember-auto-import": "^2.4.1",
     "ember-cli": "~3.28.3",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",
@@ -44,7 +45,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^4.6.0",
+    "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.0",
     "ember-source": "~3.28.8",
     "ember-source-channel-url": "^2.0.1",
@@ -57,7 +58,9 @@
     "jest": "^27.5.1",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit-dom": "^1.2.0"
+    "qunit": "^2.19.1",
+    "qunit-dom": "^2.0.0",
+    "webpack": "^5.72.1"
   },
   "engines": {
     "node": ">= 16"

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,6 +21,13 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="ember-testing-container">
+        <div id="ember-testing"></div>
+      </div>
+    </div>
+
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,6 +2,11 @@ import Application from 'dummy/app';
 import config from 'dummy/config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import { setup } from 'qunit-dom';
+
+import * as QUnit from 'qunit';
+
+setup(QUnit.assert);
 
 setApplication(Application.create(config.APP));
 


### PR DESCRIPTION
This is an attempt at fixing Storybook on Ember 4.1+ by explicitly setting the `Ember` global in the generated `preview-head.html`. It's working for our Storybook setup. 

It's admittedly a sledge hammer solution, but it's working until there's a proper solution. 

This should "fix" #103 as well as storybookjs/storybook#18028