### PR TITLE
Lazily require ember-cli-addon-docs-yuidoc when needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,11 @@
 
 const fs = require('fs');
 const path = require('path');
-const YUIDocsGenerator = require('ember-cli-addon-docs-yuidoc/lib/broccoli/generator');
 const Funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
 const { parse, generatePreviewHead } = require('./lib/util');
+
+let YUIDocsGenerator;
 
 module.exports = {
   name: require('./package').name,
@@ -45,6 +46,10 @@ module.exports = {
     let componentJS = new Funnel('.', {
       include: componentFilePathPatterns,
     });
+
+    if (!YUIDocsGenerator) {
+      YUIDocsGenerator = require('ember-cli-addon-docs-yuidoc/lib/broccoli/generator');
+    }
 
     let componentDocsTree = new YUIDocsGenerator([componentJS], {
       project: this.project,


### PR DESCRIPTION
Hi!

In an attempt to workaround issue #124, we excluded `yui` from our dependencies.
However, it turns out that `ember-cli-storybook` always requires `ember-cli-addon-docs-yuidoc` (which requires `yuidocjs`, which requires `yui` :skull_and_crossbones:).

So, this PR aims at allowing not to have `yui` in our dependencies if it is not used, by lazily requiring `ember-cli-addon-docs-yuidoc` when it is necessary.

Hope this helps.