### PR TITLE
revert: Downgrade ember-source-channel-url from 3.0.0 to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.0",
     "ember-source": "~3.28.8",
-    "ember-source-channel-url": "^3.0.0",
+    "ember-source-channel-url": "^2.0.1",
     "ember-template-lint": "^4.13.0",
     "ember-try": "^1.4.0",
     "eslint": "^7.5.0",


### PR DESCRIPTION
This reverts commit a1861d056f0ebbf5b39a19d5b953772221069592, reversing changes made to 7a08e77693fe677d76bf133efef55c2cc2c1f5a8.