### PR TITLE
Add embroider compatibility for YUIDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,19 @@ So in order to add a script tag to the generated `preview-head.html` a potential
   }
 }
 ```
-
 > It is important to note that storybook will by default serve any files out of the `public` folder. If you have custom files you would like to serve they need to exist there.
+
+## Embroider & YUIDoc
+If you want to use YUIDoc with Embroider, you will need to modify your `ember-cli-build.js` to be able to compile the documentation.
+
+```diff
+const { Webpack } = require('@embroider/webpack');
+- return require('@embroider/compat').compatBuild(app, Webpack);
++ const compiledApp = require('@embroider/compat').compatBuild(app, Webpack);
++
++ return require('@storybook/ember-cli-storybook').prerender(app, compiledApp);
+```
+
 # Troubleshooting
 
 ### Components that need routing for query parameters

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,13 +7,12 @@ module.exports = function(defaults) {
     // Add options here
   });
 
-  /*
-    This build file specifies the options for the dummy test app of this
-    addon, located in `/tests/dummy`
-    This build file does *not* influence how the addon or the app using it
-    behave. You most likely want to be modifying `./index.js` or app's build file
-  */
-
   const { maybeEmbroider } = require('@embroider/test-setup');
-  return maybeEmbroider(app);
+  const appTree = maybeEmbroider(app);
+  
+  if ('@embroider/core' in app.dependencies()) {
+    return require('./index').prerender(app, appTree);
+  } else {
+    return appTree;
+  }
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "devDependencies": {
+    "@embroider/test-setup": "^1.8.3",
     "@ember/optional-features": "^1.3.0",
     "@ember/test-helpers": "^2.8.0",
     "@embroider/test-setup": "^2.0.2",


### PR DESCRIPTION
In Embroider world, there's no `postprocessTree` hook. 

Therefore, the way we generate YUIDoc [here](https://github.com/storybookjs/ember-cli-storybook/blob/master/index.js#L32) won't work.

This refacts the index.js to be able to process YUIDoc still while being compatible with Embroider. 

Heavily inspired by https://github.com/ef4/prember/pull/64/files


Resolves https://github.com/storybookjs/ember-cli-storybook/issues/153