### PR TITLE
Add Embroider test scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,18 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16.17.x ]
-        ember: [lts-3.28, lts-3.24, 4.1, release, beta, canary, default-with-jquery, classic]
+        ember: [
+          ember-lts-3.28,
+          ember-lts-3.24,
+          ember-4.1,
+          ember-release,
+          ember-beta,
+          ember-canary,
+          ember-default-with-jquery,
+          ember-classic,
+          embroider-safe,
+          embroider-optimized
+        ]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -50,5 +61,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm install
-      - name: Run tests for ember-${{ matrix.ember }}
-        run: ./node_modules/.bin/ember try:one ember-${{ matrix.ember }}
+      - name: Run tests for ${{ matrix.ember }}
+        run: ./node_modules/.bin/ember try:one ${{ matrix.ember }}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function() {
   return {
@@ -81,7 +82,9 @@ module.exports = async function() {
             edition: 'classic'
           }
         }
-      }
+      },
+      embroiderSafe({ allowedToFail: true }),
+      embroiderOptimized({ allowedToFail: true }),
     ]
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,5 +14,6 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return app.toTree();
+  const { maybeEmbroider } = require('@embroider/test-setup');
+  return maybeEmbroider(app);
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
     "@ember/test-helpers": "^2.8.0",
+    "@embroider/test-setup": "^2.0.2",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^2.4.1",


### PR DESCRIPTION
This PR adds to new CI jobs: 
- `embroider-safe`
- `embroider-optimized` 

They are allowed to fail for now as we don't know yet if we're 100% compatible, we'll remove it once they pass green.

See https://github.com/embroider-build/embroider/tree/main/packages/test-setup