### PR TITLE
📦 Remove useless ember-maybe-import-regenerator 

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
-    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.0",
     "ember-source": "~3.28.8",


### PR DESCRIPTION
This package was initially intended for IE11 support, we don't 😄.


> This exists to give applications that still service IE11 users and also wish to use async/await or generators.
https://github.com/machty/ember-maybe-import-regenerator

This should help solve this warning 
<img width="870" alt="Screenshot 2022-12-22 at 18 27 13" src="https://user-images.githubusercontent.com/15218861/209191989-6312d2ff-c5a7-4550-a7dd-a0ebea1f9023.png">



See also this issue for more https://github.com/machty/ember-maybe-import-regenerator/issues/36