### PR TITLE
Remove support for IE11 in dummy app

### DIFF
--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,18 +1,5 @@
 'use strict';
 
-const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions'
-];
-
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
-  browsers
+  browsers: ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'],
 };


### PR DESCRIPTION
This PR remove the IE11 support for the dummy app. 

This should unblock https://github.com/storybookjs/ember-cli-storybook/actions/runs/3766427941/jobs/6402942070